### PR TITLE
fix to sparse jacobian bug. Needed to fix evaluate_path to return Node instead of Float64.

### DIFF
--- a/src/FDTests.jl
+++ b/src/FDTests.jl
@@ -1655,6 +1655,11 @@ end
             72.0 72.0 48.0
             72.0 18.0 24.0
             48.0 24.0 8.0])
+
+    #test to make sure sparse_hessian/evaluate_path bug is not reintroduced (ref commit 4b4aeeb1990a15443ca87c15638dcaf7bd9d34d1)
+    a = hessian(x * y, [x, y])
+    b = sparse_hessian(x * y, [x, y])
+    @test all(a .== b)
 end
 
 @testitem "hessian_times_v" begin

--- a/src/Factoring.jl
+++ b/src/Factoring.jl
@@ -531,12 +531,12 @@ function evaluate_path(graph::DerivativeGraph, root_index::Integer, var_index::I
     if !is_tree(node_value) #root contains a variable or constant
         if is_variable(node_value)
             if variable(graph, var_index) == node_value
-                return 1.0 #taking a derivative with respect to itself, which is 1. Need to figure out a better way to get the return number type right. This will always return Float64.
+                return one(Node) #taking a derivative with respect to itself, which is 1. Need to figure out a better way to get the return number type right. This will always return Float64.
             else
-                return 0.0 #taking a derivative with respect to a different variable, which is 0.
+                return zero(Node) #taking a derivative with respect to a different variable, which is 0.
             end
         else
-            return 0.0 #root is a constant
+            return zero(Node) #root is a constant
         end
     else #root contains a graph which has been factored so that there should be a single linear path from each root to each variable with no branching
         return follow_path(graph, root_index, var_index)

--- a/src/Jacobian.jl
+++ b/src/Jacobian.jl
@@ -92,17 +92,13 @@ function _sparse_symbolic_jacobian!(graph::DerivativeGraph, partial_variables::A
     variable_index = map(x -> variable_postorder_to_index(graph, postorder_number(graph, x)), partial_variables)
 
     for root in 1:codomain_dimension(graph)
-        # reach_vars = reachable_variables(graph, root_index_to_postorder_number(graph, root))
         for (i, partial_var) in pairs(partial_variables)
             partial_index = variable_node_to_index(graph, partial_var) #make sure variable is in the domain of the graph
             if partial_index !== nothing
-                # if reach_vars[partial_index] #make sure variable is reachable from this root. If ∂fⱼ/∂xᵢ ≡ 0 then there will not be a path from fⱼ to xᵢ so don't need a separate check for this case.
                 tmp = evaluate_path(graph, root, partial_index)
-                println(typeof(tmp))
                 if !is_zero(tmp)
                     push!(row_indices, root)
                     push!(col_indices, i)
-                    # push!(values, evaluate_path(graph, root, partial_index))
                     push!(values, tmp)
                 end
             end

--- a/src/Jacobian.jl
+++ b/src/Jacobian.jl
@@ -92,14 +92,18 @@ function _sparse_symbolic_jacobian!(graph::DerivativeGraph, partial_variables::A
     variable_index = map(x -> variable_postorder_to_index(graph, postorder_number(graph, x)), partial_variables)
 
     for root in 1:codomain_dimension(graph)
-        reach_vars = reachable_variables(graph, root_index_to_postorder_number(graph, root))
+        # reach_vars = reachable_variables(graph, root_index_to_postorder_number(graph, root))
         for (i, partial_var) in pairs(partial_variables)
             partial_index = variable_node_to_index(graph, partial_var) #make sure variable is in the domain of the graph
             if partial_index !== nothing
-                if reach_vars[partial_index] #make sure variable is reachable from this root. If ∂fⱼ/∂xᵢ ≡ 0 then there will not be a path from fⱼ to xᵢ so don't need a separate check for this case.
+                # if reach_vars[partial_index] #make sure variable is reachable from this root. If ∂fⱼ/∂xᵢ ≡ 0 then there will not be a path from fⱼ to xᵢ so don't need a separate check for this case.
+                tmp = evaluate_path(graph, root, partial_index)
+                println(typeof(tmp))
+                if !is_zero(tmp)
                     push!(row_indices, root)
                     push!(col_indices, i)
-                    push!(values, evaluate_path(graph, root, partial_index))
+                    # push!(values, evaluate_path(graph, root, partial_index))
+                    push!(values, tmp)
                 end
             end
         end
@@ -251,6 +255,11 @@ function hessian(expression::Node, variable_order::AbstractVector{S}) where {S<:
 end
 export hessian
 
+"""Compute the symbolic Hessian. Returns a sparse matrix of symbolic expressions. 
+Can be used in combination with `make_function` to generate an executable that
+ will return a sparse matrix or take one as an in-place argument. 
+Example:
+"""
 function sparse_hessian(expression::Node, variable_order::AbstractVector{S}) where {S<:Node}
     gradient = jacobian([expression], variable_order)
     return sparse_jacobian(vec(gradient), variable_order)


### PR DESCRIPTION
sparse hessian and hessian didn't return same value for function x*y. Sparse jacobian wasn't computing correct value. Several sources - wasn't using evaluate_path to determine whether a partial existed so if the root node was also a variable it wasn't evaluated properly. evaluate_path handles this correctly. But evaluate_path was returning Float64 instead of Node if the result was 0 or 1 and this caused type problems in sparse_jacobian. Fixed evaluate_path to always return Node objects.