### PR TITLE
added Base.transpose,Base.adjoint methods for nodes so transpose and adjoint operators will work.

### DIFF
--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -276,6 +276,8 @@ function Base.promote(a::Node{T,0}, b::Node{S,0}) where {T<:Real,S<:Real}
 end
 
 Base.conj(a::Node) = a #need to define this because dot and probably other linear algebra functions call this.
+Base.adjoint(a::Node) = a
+Base.transpose(a::Node) = a
 
 # Pre-defined derivatives
 import DiffRules


### PR DESCRIPTION
fix transpose and adjoint problem. needed these rules:

Base.transpose(a::Node) = a
Base.adjoint(a::Node) = a