### PR TITLE
added special Node constructors so Base.oneunit function won't crash.

### DIFF
--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -53,6 +53,13 @@ struct Node{T,N} <: Number
     Node(a::S) where {S<:Symbol} = new{S,0}(a, nothing)
 end
 
+
+#need these methods because the linear algebra operations (and maybe others) call oneunit(a) which does something like T(one(T)). If these methods aren't defined oneunit will crash.
+Node{T,0}(a) where {T} = Node(a) #not entirely sure why this needs to be defined but the linear algebra functions complain if it isn't.
+Node{T,0}(a::Node{T,0}) where {T<:Any} = Node(a)
+Node{T,1}(a::Node{T,1}) where {T<:Any} = Node(a)
+Node{T,2}(a::Node{T,2}) where {T<:Any} = Node(a)
+
 #convenience function to extract the fields from Node object to check cache
 function check_cache(a::Node{T,N}, cache) where {T,N}
     if children(a) !== nothing

--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -54,11 +54,15 @@ struct Node{T,N} <: Number
 end
 
 
-#need these methods because the linear algebra operations (and maybe others) call oneunit(a) which does something like T(one(T)). If these methods aren't defined oneunit will crash.
+#need these methods because the linear algebra operations (and maybe others) call oneunit(a), and maybe other methods which do similar things. oneunit does something like T(one(T)). If these methods aren't defined oneunit will crash.
 Node{T,0}(a) where {T} = Node(a) #not entirely sure why this needs to be defined but the linear algebra functions complain if it isn't.
 Node{T,0}(a::Node{T,0}) where {T<:Any} = Node(a)
 Node{T,1}(a::Node{T,1}) where {T<:Any} = Node(a)
 Node{T,2}(a::Node{T,2}) where {T<:Any} = Node(a)
+#you might think you could do this instead and save a few lines of code but this is ambiguous for the case Node{Int64,0}(a::nt64):
+# Node{T,N}(a::Node{S,N2}) where {T,S,N,N2} = a
+# Node{T,0}(a) where {T} = Node(a)
+
 
 #convenience function to extract the fields from Node object to check cache
 function check_cache(a::Node{T,N}, cache) where {T,N}

--- a/src/FDTests.jl
+++ b/src/FDTests.jl
@@ -1437,7 +1437,7 @@ end
 
 @testitem "sparse_jacobian" begin
     using FastDifferentiation.FDTests
-    import FastDifferentiation as FD
+    using FastDifferentiation.FDInternals
 
     @variables x y z
 
@@ -1762,7 +1762,7 @@ end
 
 @testitem "reverse_AD" begin
     using FastDifferentiation.FDTests
-    import FastDifferentiation as FD
+    using FastDifferentiation.FDInternals
 
     sph_func = spherical_harmonics(7)
     sph_jac = jacobian(FD.roots(sph_func), FD.variables(sph_func))

--- a/src/FastDifferentiation.jl
+++ b/src/FastDifferentiation.jl
@@ -51,21 +51,6 @@ function draw_dot end
 function write_dot end
 
 
-function test()
-    x, graph, _, _ = simple_dominator_graph()
-
-    factor!(graph)
-    fedge = edges(graph, 1, 4)[1]
-    tmp0 = make_function([value(fedge)], [x])
-    dfsimp(x) = tmp0([x])[1]
-    x, graph, _, _ = simple_dominator_graph() #x is a new variable so have to make a new Node(x)
-
-    tmp00 = make_function([root(graph, 1)], [x])
-    origfsimp(x) = tmp00([x])[1]
-    @assert isapprox(FiniteDifferences.central_fdm(5, 1)(origfsimp, 3), dfsimp(3)[1])
-end
-
-include("FDTests.jl")
 
 
 end # module

--- a/src/FastDifferentiation.jl
+++ b/src/FastDifferentiation.jl
@@ -50,7 +50,7 @@ function make_dot_file end
 function draw_dot end
 function write_dot end
 
-
+include("FDTests.jl")
 
 
 end # module


### PR DESCRIPTION
The linear algebra operations call Base.oneunit on Node objects, which does this:
```
T(one(T))
```
where T is the type of the Node object. If this type is Node{cos,1} then the method Node{cos,1}(a) needs to be defined or oneunit will crash. Some other functions inside StaticArrays also seem to need these types of methods.