### PR TITLE
Fix code generation in the presence of constants and zeros

### DIFF
--- a/src/FDTests.jl
+++ b/src/FDTests.jl
@@ -1928,7 +1928,7 @@ end
     end
 
     @info "evaluate with exotic eltype"
-    test_code_generation((1.0)) do x
+    test_code_generation(Complex(1.0)) do x
         [1, 2.1 * x[1], 2]
     end
 end

--- a/src/FDTests.jl
+++ b/src/FDTests.jl
@@ -1855,7 +1855,6 @@ end
 end
 
 @testitem "more init with constant" begin
-    using Random
     using FastDifferentiation
     using FastDifferentiation: Node
 
@@ -1869,18 +1868,19 @@ end
         @show f_callable
         result = f_callable(input)
         @test isapprox(result, correct_result)
+        @test typeof(result) <: typeof(correct_result)
 
         # in_place, init_with_zeros
         f_callable_init! = make_function(f_node, x_node; in_place=true, init_with_zeros=true)
         @show f_callable_init!
-        result = rand(length(correct_result))
+        result = similar(correct_result)
         f_callable_init!(result, input) == correct_result
         @test isapprox(result, correct_result)
 
         # in_place, !init_with_zeros
         f_callable_no_init! = make_function(f_node, x_node; in_place=true, init_with_zeros=false)
         @show f_callable_no_init!
-        result = rand(length(correct_result))
+        result = similar(correct_result)
         result_copy = copy(result)
         f_callable_no_init!(result, input)
         for i in eachindex(result)
@@ -1892,33 +1892,44 @@ end
 
     # systematically enumerate the four different branches of `make_Expr`:
     # all constant, mostly zeros
+    @info "all constant, mostly zeros"
     test_code_generation([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]) do x
         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
     end
 
     # all constant, some zeros
+    @info "all constant, some zeros"
     test_code_generation([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]) do x
         [6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0]
     end
 
     # mostly constants
+    @info "mostly constants"
     test_code_generation(3.0) do x
         [2.1 * x[1], 1, 2]
     end
 
     # non-constant at non-first position
+    @info "non-constant at non-first position"
     test_code_generation(3.0) do x
         [1, 2.1 * x[1], 2]
     end
 
     # mostly zeros
+    @info "mostly zeros"
     test_code_generation(3.0) do x
         [x[1]^2, 0, 0]
     end
 
     # all non-constant
+    @info "all non-constant"
     test_code_generation(3.0) do x
         [2.1 * x[1], x[1]^2, sqrt(x[1])]
+    end
+
+    @info "evaluate with exotic eltype"
+    test_code_generation((1.0)) do x
+        [1, 2.1 * x[1], 2]
     end
 end
 


### PR DESCRIPTION
 This fixes the following issues within code generation:

1. If everything is constant, only initialize zeros if `!initialize_with_zeros`.

3. Avoid incorrect const-construction for `func_array` elements that are not constant.
    - previously, nodes such as `x^2` would be converted to const values of `^` which slowed down the code a lot and broke the in-place version of `make_function`. I have also added some tests that provoke this issue in the original code.

4. Skip assignments of constants/zeros that have been set during array construction
    - Previously, some of the constants were set during construction and then also assigned as `result[i] = ...` in the evaluation of the computation graph. This issue is also visible in the code generated for the newly added tests when running those on `main`, e.g.,
<details><summary>Click to expand generated code</summary>

Code generation for `f(x) = [1, 2, x^2]`

**Previously**
```julia
f_callable = RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(:input_variables,), FastDifferentiation.var"#_RGF_ModTag", FastDifferentiation.var"#_RGF_ModTag", (0x2a292425, 0x78dd738d, 0xa26e74b0, 0x1b0f8c0d, 0xea9743cd), Expr}(quote
    #= /home/lassepe/.julia/dev/FastDifferentiation/src/CodeGeneration.jl:204 =#
    #= /home/lassepe/.julia/dev/FastDifferentiation/src/CodeGeneration.jl:204 =# @inbounds begin
            #= /home/lassepe/.julia/dev/FastDifferentiation/src/CodeGeneration.jl:205 =#
            begin
                result = copy(Any[1, 2, ^])
                result[1] = 1
                result[2] = 2
                var"##7865" = input_variables[1] ^ 2
                result[3] = var"##7865"
                return result
            end
        end
end)
```

**This PR**
```julia
f_callable = RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(:input_variables,), FastDifferentiation.var"#_RGF_ModTag", FastDifferentiation.var"#_RGF_ModTag", (0xdaa20b48, 0x03cf19b1, 0xbbc260b5, 0x7a26e996, 0x1ee58f75), Expr}(quote
    #= /home/lassepe/worktree/FastDifferentiation.jl/src/CodeGeneration.jl:180 =#
    #= /home/lassepe/worktree/FastDifferentiation.jl/src/CodeGeneration.jl:180 =# @inbounds begin
            #= /home/lassepe/worktree/FastDifferentiation.jl/src/CodeGeneration.jl:181 =#
            begin
                result_element_type = promote_type(Float64, eltype(input_variables))
                result = Array{result_element_type}(undef, (3,))
                result[[1, 2]] .= [1.0, 2.0]
                var"##291" = input_variables[1] ^ 2
                result[3] = var"##291"
                return result
            end
        end
end)
```
</details>