### PR TITLE
Factorization algorithm computes incorrect result for some large complex graphs.

### DIFF
--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -44,7 +44,7 @@ export @variables
 
 
 struct Node <: Number
-    node_value
+    node_value::Union{Function,<:Real,Symbol}
     children::Union{Nothing,MVector{N,Node}} where {N} #initially used SVector but this was incredibly inefficient. Possibly because the compiler was inlining the entire graph into a single static structure, which could lead to very long == and hashing times.
 
 

--- a/src/Factoring.jl
+++ b/src/Factoring.jl
@@ -625,3 +625,32 @@ function number_of_operations(jacobian::AbstractArray{T}) where {T<:Node}
     end
     return count
 end
+
+function new_factor_subgraph!(a::FactorableSubgraph{T}) where {T}
+    local new_edge::PathEdge{T}
+    if subgraph_exists(subgraph)
+
+        if is_branching(subgraph) #handle the uncommon case of factorization creating new factorable subgraphs internal to subgraph
+            sum = evaluate_branching_subgraph(subgraph)
+            new_edge = make_factored_edge(subgraph, sum)
+        else
+            sum = evaluate_subgraph(subgraph)
+            # if value(sum) == 0
+            #     display(subgraph)
+            #     write_dot("sph.svg", graph(subgraph), value_labels=true, reachability_labels=false, start_nodes=[24])
+            # end
+
+            # # @assert value(sum) != 0
+
+            new_edge = make_factored_edge(subgraph, sum)
+        end
+        add_non_dom_edges!(subgraph)
+        #reset roots in R, if possible. All edges earlier in the path than the first vertex with more than one child cannot be reset.
+        edges_to_delete = reset_edge_masks!(subgraph)
+        for edge in edges_to_delete
+            delete_edge!(graph(subgraph), edge)
+        end
+
+        add_edge!(graph(subgraph), new_edge)
+    end
+end


### PR DESCRIPTION
Fixes #65

Factorization can create new factorable subgraphs interior to an existing subgraph. Themost general way to solve this problem is to rerun the dominance calculation on each subgraph where this condition is detected and then to recursively factor these subgraphs before factoring the containing subgraph.

This seemed too computationally expensive so I had special case code which appeared to work. But larger graphs tend to also have more complex internal structure which is more likely to give rise to these internal factorable subgraphs. The current code eventually fails as graphs get larger and their structure becomes more convoluted.

This PR will replace the existing algorithm with a dominance recomputation which will be executed only if internal subgraph creation is detected.

