### PR TITLE
`make_function` returns wrong result with sparse Jacobian for very simple functions only

### DIFF
--- a/src/CodeGeneration.jl
+++ b/src/CodeGeneration.jl
@@ -224,6 +224,7 @@ function make_Expr(A::SparseMatrixCSC{T,Ti}, input_variables::AbstractVector{S},
         if in_place
             return :((result, input_variables) -> $body)
         else
+            push!(body.args, :(return result))
             return :((input_variables) -> $body)
         end
     else

--- a/test/FDTests.jl
+++ b/test/FDTests.jl
@@ -1866,4 +1866,25 @@ end
     @test isapprox(hexe([1, 1]), [0 0; 0 0])
 end
 
+@testitem "make_function returns wrong result with sparse Jacobian for very simple functions only" begin
+    #issue "https://github.com/brianguenter/FastDifferentiation.jl/issues/67#issue-2217019202"
+    x = make_variables(:x, 4)
+    y = diff(x)
+    jac_sparse = sparse_jacobian(y, x)
+    jac_sparse_exe = make_function(jac_sparse, x)
+    temp = jac_sparse_exe(rand(4))
+
+    correct = [-1.0 1.0 0.0 0.0;
+        0.0 -1.0 1.0 0.0;
+        0.0 0.0 -1.0 1.0]
+    @test correct == temp
+    #used to return the vector of nonzeros stored in the sparse matrix instead of the sparse matrix itself
+    # 6-element Vector{Float64}:
+    #  -1.0
+    #   1.0
+    #  -1.0
+    #   1.0
+    #  -1.0
+    #   1.0
+end
 


### PR DESCRIPTION
Fixes #67

when in_place was false and the jacobian was constant make_function generated code which returned the vector of non zeros of the sparse matrix rather than the sparse matrix itself.

Now it returns the sparse matrix.

wrote a new test to verify this.