### PR TITLE
Patch release with fix for https://github.com/brianguenter/FastDifferentiation.jl/pull/68#issue-2218735778

### DIFF
--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -1,23 +1,6 @@
 
 
-#until I can think of a better way of structuring the caching operation it will be a single global expression cache. This precludes multithreading, unfortunately. Many other parts of the algorithm are difficult to multithread. Processing is also so quick that only large graphs would benefit from multithreading. Don't know how common these will be.
-const EXPRESSION_CACHE = IdDict()
 
-function check_cache(a::Tuple{Vararg}, cache)
-    cache_val = get(cache, a, nothing)
-    if cache_val === nothing
-        cache[a] = Node(a[1], a[2:end]...) #this should wrap everything, including basic numbers, in a Node object
-    end
-
-    return cache[a]
-end
-
-"""
-    clear_cache()
-
-Clears the global expression cache. To maximize efficiency of expressions the differentation system automatically eliminates common subexpressions by checking for their existence in the global expression cache. Over time this cache can become arbitrarily large. Best practice is to clear the cache before you start defining expressions, define your expressions and then clear the cache."""
-clear_cache() = empty!(EXPRESSION_CACHE)
-export clear_cache
 
 """
 @variables args...
@@ -60,6 +43,25 @@ struct Node <: Number
 
     Node(a::S) where {S<:Symbol} = new(a, nothing)
 end
+
+#until I can think of a better way of structuring the caching operation it will be a single global expression cache. This precludes multithreading, unfortunately. Many other parts of the algorithm are difficult to multithread. Processing is also so quick that only large graphs would benefit from multithreading. Don't know how common these will be.
+const EXPRESSION_CACHE = IdDict{Any,Node}()
+
+function check_cache(a::Tuple{Vararg}, cache::IdDict{Any,Node})::Node
+    cache_val = get(cache, a, nothing)
+    if cache_val === nothing
+        cache[a] = Node(a[1], a[2:end]...) #this should wrap everything, including basic numbers, in a Node object
+    end
+
+    return cache[a]
+end
+
+"""
+    clear_cache()
+
+Clears the global expression cache. To maximize efficiency of expressions the differentation system automatically eliminates common subexpressions by checking for their existence in the global expression cache. Over time this cache can become arbitrarily large. Best practice is to clear the cache before you start defining expressions, define your expressions and then clear the cache."""
+clear_cache() = empty!(EXPRESSION_CACHE)
+export clear_cache
 
 struct Differential
     variables_wrt::MVector{N,Node} where {N}
@@ -181,7 +183,7 @@ function simplify_check_cache(::typeof(^), a, b, cache)
     end
 end
 
-function simplify_check_cache(::typeof(*), na, nb, cache)
+function simplify_check_cache(::typeof(*), na, nb, cache)::Node
     a = Node(na)
     b = Node(nb)
 
@@ -242,7 +244,7 @@ function matching_terms(lchild, rchild)
     end
 end
 
-function simplify_check_cache(::typeof(+), na, nb, cache)
+function simplify_check_cache(::typeof(+), na, nb, cache)::Node
     a = Node(na)
     b = Node(nb)
 
@@ -267,7 +269,7 @@ function simplify_check_cache(::typeof(+), na, nb, cache)
     end
 end
 
-function simplify_check_cache(::typeof(-), na, nb, cache)
+function simplify_check_cache(::typeof(-), na, nb, cache)::Node
     a = Node(na)
     b = Node(nb)
     if a === b
@@ -288,7 +290,7 @@ function simplify_check_cache(::typeof(-), na, nb, cache)
     end
 end
 
-function simplify_check_cache(::typeof(/), na, nb, cache)
+function simplify_check_cache(::typeof(/), na, nb, cache)::Node
     a = Node(na)
     b = Node(nb)
 
@@ -303,13 +305,13 @@ end
 
 
 
-simplify_check_cache(f::Any, na, cache) = check_cache((f, na), cache)
+simplify_check_cache(f::Any, na, cache) = check_cache((f, na), cache)::Node
 
 """
     simplify_check_cache(::typeof(-), a, cache)
 
 Special case only for unary -. No simplifications are currently applied to any other unary functions"""
-function simplify_check_cache(::typeof(-), a, cache)
+function simplify_check_cache(::typeof(-), a, cache)::Node
     na = Node(a) #this is safe because Node constructor is idempotent
     if arity(na) == 1 && typeof(value(na)) == typeof(-)
         return children(na)[1]

--- a/test/FDTests.jl
+++ b/test/FDTests.jl
@@ -1888,3 +1888,23 @@ end
     #   1.0
 end
 
+@testitem "incorrect inference for matrix arithmetic" begin
+    "Type inference is not precise enough when performing arithmetic operations on matrices of Node. These all return Matrix{Any} instead of Matrix{Node} which can cause errors when trying to compute Jacobians."
+
+    @variables a1 a2 b1 b2 c1 c2 d1 d2
+
+
+    thing1 = [a1 b1; c1 d1]
+
+    thing2 = [a2 b2; c2 d2]
+
+
+    function type_test(matrix::Matrix{T}) where {T}
+        return T <: FastDifferentiation.Node
+    end
+
+    @assert type_test(thing1 * thing2)
+    @assert type_test(thing1 - thing2)
+    @assert type_test(thing1 + thing2)
+end
+


### PR DESCRIPTION
Type inference is not precise enough when performing arithmetic operations on matrices of Node. These all return Matrix{Any} instead of Matrix{Node} which can cause errors when trying to compute Jacobians. 

This patch will fix the problem by declaring the return type of simplify_check_cache to give the compiler enough information to infer correctly.

Here is an example of the problem:

julia> @variables a1 a2 b1 b2 c1 c2 d1 d2
d2

julia> thing1 = [a1 b1; c1 d1]
2×2 Matrix{FastDifferentiation.Node}:
 a1  b1
 c1  d1

julia> thing2 = [a2 b2; c2 d2]
2×2 Matrix{FastDifferentiation.Node}:
 a2  b2
 c2  d2

julia> 

julia> thing3 = thing1 * thing2
2×2 Matrix{Any}:
 ((a1 * a2) + (b1 * c2))  ((a1 * b2) + (b1 * d2))
 ((c1 * a2) + (d1 * c2))  ((c1 * b2) + (d1 * d2))

julia> jacobian(thing3, [a1, c2])
ERROR: MethodError: no method matching jacobian(::Matrix{Any}, ::Vector{FastDifferentiation.Node})

Closest candidates are:
  jacobian(::AbstractVector{T}, ::AbstractVector{S}) where {T<:FastDifferentiation.Node, S<:FastDifferentiation.Node}
   @ FastDifferentiation C:\Users\seatt\.julia\dev\FastDifferentiation\src\Jacobian.jl:90

Stacktrace:
 [1] top-level scope
   @ REPL[13]:1

julia> jacobian(vec(thing3), [a1, c2])
ERROR: MethodError: no method matching jacobian(::Vector{Any}, ::Vector{FastDifferentiation.Node})