### PR TITLE
Brianguenter/issue76

### DIFF
--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -216,34 +216,6 @@ function simplify_check_cache(::typeof(*), na, nb, cache)::Node
     end
 end
 
-function find_term(a::Node)
-    if typeof(value(a)) == typeof(-)
-        constant = -1
-        term = children(a)[1]
-    elseif typeof(value(a)) == typeof(*) && is_constant(children(a)[1])
-        constant = children(a)[1]
-        term = children(a)[2]
-    else
-        constant = nothing
-        term = nothing
-    end
-    return term, constant
-end
-
-function matching_terms(lchild, rchild)
-    if lchild === rchild
-        return (1, 1, lchild)
-    else
-        lterm, lconstant = find_term(lchild)
-        rterm, rconstant = find_term(rchild)
-        if lterm !== nothing && rterm !== nothing && lterm === rterm
-            return (lconstant, rconstant, lterm)
-        else
-            return nothing
-        end
-    end
-end
-
 function simplify_check_cache(::typeof(+), na, nb, cache)::Node
     a = Node(na)
     b = Node(nb)
@@ -262,8 +234,6 @@ function simplify_check_cache(::typeof(+), na, nb, cache)::Node
         return Node(value(a) + value(children(b)[1])) + children(b)[2]
     elseif a === b
         return 2 * a
-    elseif (tmp = matching_terms(a, b)) !== nothing
-        return (tmp[1] + tmp[2]) * tmp[3]
     else
         return check_cache((+, a, b), cache)
     end
@@ -282,9 +252,6 @@ function simplify_check_cache(::typeof(-), na, nb, cache)::Node
         return a + children(b)[1]
     elseif is_constant(a) && is_constant(b)
         return Node(value(a) - value(b))
-
-    elseif (tmp = matching_terms(a, b)) !== nothing
-        return (tmp[1] - tmp[2]) * tmp[3]
     else
         return check_cache((-, a, b), cache)
     end

--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -262,6 +262,8 @@ function simplify_check_cache(::typeof(+), na, nb, cache)::Node
         return Node(value(a) + value(children(b)[1])) + children(b)[2]
     elseif a === b
         return 2 * a
+    elseif (tmp = matching_terms(a, b)) !== nothing
+        return (tmp[1] + tmp[2]) * tmp[3]
     else
         return check_cache((+, a, b), cache)
     end

--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -282,6 +282,8 @@ function simplify_check_cache(::typeof(-), na, nb, cache)::Node
         return a + children(b)[1]
     elseif is_constant(a) && is_constant(b)
         return Node(value(a) - value(b))
+    elseif (tmp = matching_terms(a, b)) !== nothing
+        return (tmp[1] - tmp[2]) * tmp[3]
     else
         return check_cache((-, a, b), cache)
     end

--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -216,6 +216,34 @@ function simplify_check_cache(::typeof(*), na, nb, cache)::Node
     end
 end
 
+function find_term(a::Node)
+    if typeof(value(a)) == typeof(-)
+        constant = -1
+        term = children(a)[1]
+    elseif typeof(value(a)) == typeof(*) && is_constant(children(a)[1])
+        constant = children(a)[1]
+        term = children(a)[2]
+    else
+        constant = nothing
+        term = nothing
+    end
+    return term, constant
+end
+
+function matching_terms(lchild, rchild)
+    if lchild === rchild
+        return (1, 1, lchild)
+    else
+        lterm, lconstant = find_term(lchild)
+        rterm, rconstant = find_term(rchild)
+        if lterm !== nothing && rterm !== nothing && lterm === rterm
+            return (lconstant, rconstant, lterm)
+        else
+            return nothing
+        end
+    end
+end
+
 function simplify_check_cache(::typeof(+), na, nb, cache)::Node
     a = Node(na)
     b = Node(nb)

--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -216,31 +216,26 @@ function simplify_check_cache(::typeof(*), na, nb, cache)::Node
     end
 end
 
-function find_term(a::Node)
-    if typeof(value(a)) == typeof(-)
-        constant = -1
-        term = children(a)[1]
-    elseif typeof(value(a)) == typeof(*) && is_constant(children(a)[1])
-        constant = children(a)[1]
-        term = children(a)[2]
+constant_product(a::Node) = value(a) == Base.:* && is_constant(children(a)[1])
+
+function constant_and_term(a::Node)
+    if constant_product(a)
+        return children(a)[1], children(a)[2]
+    elseif is_negate(a)
+        return -1, children(a)[1]
     else
-        constant = 1
-        term = a
+        return 1, a
     end
-    return term, constant
 end
 
-function matching_terms(lchild, rchild)
-    if lchild === rchild
-        return (1, 1, lchild)
+"""Used as a helper function for simplifying c1*a ± c2*a => (c1 ± c2)*a where c1,c2 are constants"""
+function constant_sum_simplification(lchild::Node, rchild::Node)
+    lconstant, lterm = constant_and_term(lchild)
+    rconstant, rterm = constant_and_term(rchild)
+    if lterm === rterm
+        return (lconstant, rconstant, lterm)
     else
-        lterm, lconstant = find_term(lchild)
-        rterm, rconstant = find_term(rchild)
-        if lterm !== nothing && rterm !== nothing && lterm === rterm
-            return (lconstant, rconstant, lterm)
-        else
-            return nothing
-        end
+        return nothing
     end
 end
 
@@ -262,7 +257,7 @@ function simplify_check_cache(::typeof(+), na, nb, cache)::Node
         return Node(value(a) + value(children(b)[1])) + children(b)[2]
     elseif a === b
         return 2 * a
-    elseif (tmp = matching_terms(a, b)) !== nothing
+    elseif (tmp = constant_sum_simplification(a, b)) !== nothing #simplify c1*a + c2*a => (c1+c2)*a where c1,c2 are constants
         return (tmp[1] + tmp[2]) * tmp[3]
     else
         return check_cache((+, a, b), cache)
@@ -282,7 +277,7 @@ function simplify_check_cache(::typeof(-), na, nb, cache)::Node
         return a + children(b)[1]
     elseif is_constant(a) && is_constant(b)
         return Node(value(a) - value(b))
-    elseif (tmp = matching_terms(a, b)) !== nothing
+    elseif (tmp = constant_sum_simplification(a, b)) !== nothing #simplify c1*a - c2*a => (c1-c2)*a where c1,c2 are constants
         return (tmp[1] - tmp[2]) * tmp[3]
     else
         return check_cache((-, a, b), cache)

--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -224,8 +224,8 @@ function find_term(a::Node)
         constant = children(a)[1]
         term = children(a)[2]
     else
-        constant = nothing
-        term = nothing
+        constant = 1
+        term = a
     end
     return term, constant
 end

--- a/test/FDTests.jl
+++ b/test/FDTests.jl
@@ -1774,6 +1774,12 @@ end
     import FastDifferentiation as FD
     FD.@variables x
 
+    f = x + x
+    @test f === 2 * x
+    f = (-1 * x) + x
+    @test f == 0
+    f = x + (-1 * x)
+    @test f == 0
     f = 2x + 3x
     @test f === 5 * x
     f2 = -x + x
@@ -1973,6 +1979,12 @@ end
     @test type_test(thing1 - thing2)
     @test type_test(thing1 + thing2)
 end
+
+# @testitem "simplest test for incorrect algebraic simplification" begin
+#     @variables ri1 rj1 rk1
+#     g = (ri1 - rk1) + (ri1 - rj1)
+#     @test typeof(value(g)) ==
+# end
 
 @testitem "check fix for incorrect algebraic simplification" begin #test for fix for bug https://github.com/brianguenter/FastDifferentiation.jl/issues/76#issue-2255470350
     using LinearAlgebra


### PR DESCRIPTION
algebraic simplification rulec1*a ± c2*a => (c1 ± c2)*a where c1,c2 are constants produced incorrect results. This is a fix for the problem.