### PR TITLE
methods with unbound static parameters

### DIFF
--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -631,7 +631,7 @@ julia> make_variables(:x,2,3,2)
  x2_1_2  x2_2_2  x2_3_2
 ```
  """
-function make_variables(name::Symbol, array_size::T...) where {T}
+function make_variables(name::Symbol, array_size...)
     result = Array{Node,length(array_size)}(undef, array_size...)
 
     for i in CartesianIndices((UnitRange.(1, array_size)))

--- a/src/Factoring.jl
+++ b/src/Factoring.jl
@@ -150,16 +150,14 @@ function compute_factorable_subgraphs(graph::DerivativeGraph{T}) where {T}
     pdom_subgraphs = Dict{Tuple{T,T},BitVector}()
     dom_subgraphs = Dict{Tuple{T,T},BitVector}()
 
-    function set_dom_bits!(subgraph::Union{Nothing,Tuple{T,T}}, all_subgraphs::Dict, var_or_root_index::Integer, bit_dimension::Integer) where {T<:Integer}
-        if subgraph !== nothing
-            existing_subgraph = get(all_subgraphs, subgraph, nothing)
-            if existing_subgraph !== nothing
-                all_subgraphs[subgraph][var_or_root_index] = 1
-            else
-                tmp = falses(bit_dimension)
-                tmp[var_or_root_index] = 1
-                all_subgraphs[subgraph] = tmp
-            end
+    function set_dom_bits!(subgraph::Tuple{T,T}, all_subgraphs::Dict, var_or_root_index::Integer, bit_dimension::Integer) where {T<:Integer}
+        existing_subgraph = get(all_subgraphs, subgraph, nothing)
+        if existing_subgraph !== nothing
+            all_subgraphs[subgraph][var_or_root_index] = 1
+        else
+            tmp = falses(bit_dimension)
+            tmp[var_or_root_index] = 1
+            all_subgraphs[subgraph] = tmp
         end
     end
 
@@ -171,7 +169,9 @@ function compute_factorable_subgraphs(graph::DerivativeGraph{T}) where {T}
 
         for dominated in keys(temp_dom)
             dsubgraph = dom_subgraph(graph, root_index, dominated, temp_dom)
-            set_dom_bits!(dsubgraph, dom_subgraphs, root_index, codomain_dimension(graph))
+            if dsubgraph !== nothing
+                set_dom_bits!(dsubgraph, dom_subgraphs, root_index, codomain_dimension(graph))
+            end
         end
     end
 
@@ -181,7 +181,9 @@ function compute_factorable_subgraphs(graph::DerivativeGraph{T}) where {T}
 
         for dominated in keys(temp_dom)
             psubgraph = pdom_subgraph(graph, variable_index, dominated, temp_dom)
-            set_dom_bits!(psubgraph, pdom_subgraphs, variable_index, domain_dimension(graph))
+            if psubgraph !== nothing
+                set_dom_bits!(psubgraph, pdom_subgraphs, variable_index, domain_dimension(graph))
+            end
         end
     end
 

--- a/src/Jacobian.jl
+++ b/src/Jacobian.jl
@@ -371,7 +371,10 @@ julia> derivative(A,t,t)
  6    0.0
 ```
 """
-function derivative(A::AbstractArray{<:Node}, variables::T...) where {T<:Node}
+function derivative(A::AbstractArray{<:Node}, variables...)
+    if variables === ()
+        throw(ErrorException("derivative function requires at least one variable argument to be differentiated with respect to. You had none."))
+    end
     var = variables[1]
     mat = _derivative(A, var)
     rest = variables[2:end]
@@ -384,7 +387,10 @@ end
 export derivative
 
 """Convenience `derivative` for scalar functions. Takes a scalar input and returns a scalar output"""
-function derivative(A::Node, variables::T...) where {T<:Node}
+function derivative(A::Node, variables...)
+    if variables === ()
+        throw(ErrorException("derivative function requires at least one variable argument to be differentiated with respect to. You had none."))
+    end
     temp = derivative([A], variables...)
     @assert length(temp) == 1
     derivative([A], variables...)[1]


### PR DESCRIPTION
Fixes #83

Several functions were defined like this:
func(a,b::T...) where{T}. If the b argument was empty then the T parameter would be undefined. 

This PR fixes all these functions so they now pass Test.detect_unbound_args().