### PR TITLE
Add some more base methods

### DIFF
--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -95,6 +95,18 @@ Base.zero(::Node) = Node(0)
 Base.one(::Type{Node}) = Node(1)
 Base.one(::Node) = Node(1)
 
+# These are essentially copied from Symbolics.jl:
+# https://github.com/JuliaSymbolics/Symbolics.jl/blob/e4c328103ece494eaaab2a265524a64bfbe43dbd/src/num.jl#L31-L34
+Base.eps(::Type{Node}) = Node(0)
+Base.typemin(::Type{Node}) = Node(-Inf)
+Base.typemax(::Type{Node}) = Node(Inf)
+Base.float(x::Node) = x
+
+# This one is needed because julia/base/float.jl only defines `isinf` for `Real`, but `Node
+# <: Number`.  (See https://github.com/brianguenter/FastDifferentiation.jl/issues/73)
+Base.isinf(x::Node) = !isnan(x) & !isfinite(x)
+
+
 Broadcast.broadcastable(a::Node) = (a,)
 
 value(a::Node) = a.node_value
@@ -324,6 +336,7 @@ rules = Any[]
 
 Base.convert(::Type{Node}, a::T) where {T<:Real} = Node(a)
 Base.promote_rule(::Type{<:Real}, ::Type{Node}) = Node
+Base.promote_rule(::Type{Bool}, ::Type{Node}) = Node
 
 function Base.:-(a::AbstractArray{<:Node,N}) where {N}
     if length(a) == 0


### PR DESCRIPTION
I was trying to use [Quaternionic.jl](https://github.com/moble/Quaternionic.jl) which uses `Bool`s for maximum numeric type compatibility. This required a quick addition to `ExpressionGraph.jl`. Previously FD only defines `Base.promote_rule(::Type{<:Real}, ::Type{Node})`. It might seem that this should cover `Bool <: Real`. But julia/src/bool.jl defines `promote_rule(::Type{Bool}, ::Type{T}) where T<:Number` and `Node <: Number`, so there is an ambiguity. This is fixed by redefining `Base.promote_rule(::Type{Bool}, ::Type{Node}) = Node`.

Also added methods for `eps(::Type{Node})`, `typemin(::Type{Node})`, `typemax(::Type{Node})`, `float(x::Node)` and `isinf(x::Node)` (which julia/base/float.jl only defined `isinf` for `Real` but `Node <: Number`), which were also necessary for [Quaternionic.jl](https://github.com/moble/Quaternionic.jl). 

Some of these fixes may be redundant if/when `Node <: Real` instead of `Node <: Number` (as mentioned in #73). 