### PR TITLE
would it make sense to have FastDifferentiation.Node <: Real?

### DIFF
--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -26,7 +26,7 @@ export @variables
 
 
 
-struct Node <: Number
+struct Node <: Real
     node_value
     children::Union{Nothing,MVector{N,Node}} where {N} #initially used SVector but this was incredibly inefficient. Possibly because the compiler was inlining the entire graph into a single static structure, which could lead to very long == and hashing times.
 

--- a/test/FDTests.jl
+++ b/test/FDTests.jl
@@ -333,14 +333,14 @@ end
     rts = [ctimess, cpluss]
     grnodes = [x, y, cosx, siny, cpluss, ctimess]
 
-    correct_postorder_numbers = Dict((x => 1, cosx => 2, y => 3, siny => 4, ctimess => 5, cpluss => 7))
+    correct_postorder_numbers = IdDict((x => 1, cosx => 2, y => 3, siny => 4, ctimess => 5, cpluss => 7))
 
     graph = FD.DerivativeGraph(rts)
 
 
     @test all([correct_postorder_numbers[node] == FD.postorder_number(graph, node) for node in grnodes])
 
-    correct_partials = Dict((cosx => [partial_cosx], siny => [partial_siny], ctimess => partial_times, cpluss => partial_plus))
+    correct_partials = IdDict((cosx => [partial_cosx], siny => [partial_siny], ctimess => partial_times, cpluss => partial_plus))
     #TODO need to use finite differences instead of Symbolics. 
     # for (node, partials) in pairs(correct_partials)
     #     for (i, one_partial) in pairs(partials)


### PR DESCRIPTION
Fixes #73

Many Julia libraries only work for number types <: Real which causes them not to work with FastDifferentiation. Fixing this requires a one line change from struct Node <: Number to struct Node <: Real.

Hower, one test failed because it was using doing Dict((x => 1, cosx => 2, y => 3, siny => 4, ctimess => 5, cpluss => 7)). This triggered an obscure low level error about Node not having a decompose method. Changed the Dict to an IdDict and now all tests pass.