### PR TITLE
incorrect code generation for if_else when expression is used in condition and one of the branches. 

### DIFF
--- a/src/CodeGeneration.jl
+++ b/src/CodeGeneration.jl
@@ -40,7 +40,12 @@ function _dag_to_function!(node, local_body, variable_to_index, node_to_var)
 
                     push!(true_body.args, :($(gensym(:s)) = $(temp_val))) #seems roundabout to use an assignment when really just want the value of the node but couldn't figure out how to make this work with Expr
                 else
-                    _dag_to_function!(children(node)[2], true_body, variable_to_index, node_to_var)
+                    visited = get(node_to_var, children(node)[2], nothing)
+                    if visited !== nothing
+                        push!(true_body.args, :($(gensym(:s)) = $visited))
+                    else
+                        _dag_to_function!(children(node)[2], true_body, variable_to_index, node_to_var)
+                    end
                 end
 
                 if is_leaf(false_node)
@@ -51,7 +56,12 @@ function _dag_to_function!(node, local_body, variable_to_index, node_to_var)
                     end
                     push!(false_body.args, :($(gensym(:s)) = $(temp_val))) #seems roundabout to use an assignment when really just want the value of the node but couldn't figure out how to make this work with Expr
                 else
-                    _dag_to_function!(children(node)[3], false_body, variable_to_index, node_to_var)
+                    visited = get(node_to_var, children(node)[3], nothing)
+                    if visited !== nothing
+                        push!(false_body.args, :($(gensym(:s)) = $visited))
+                    else
+                        _dag_to_function!(children(node)[3], false_body, variable_to_index, node_to_var)
+                    end
                 end
 
                 statement = :($(node_to_var[node]) = if $(if_cond_var)

--- a/test/FDTests.jl
+++ b/test/FDTests.jl
@@ -2163,4 +2163,12 @@ end
     h = make_function(g, [x, y])
     @test isnan(h([0.0, 2.0])[1])
     @test isapprox(h([1.1, 2.0])[1], 0.11532531756323319)
+
+    #ensure that functions that are defined in condition of if_else can be used as either a true or false result
+    h = make_function([if_else(sqrt(x) < 1, sqrt(x), 0.0)], [x])
+    @test isapprox(h([0.5])[1], sqrt(0.5))
+
+    h = make_function([if_else(sqrt(x) < 1, 0.0, sqrt(x))], [x])
+    @test isapprox(h([1.5])[1], sqrt(1.5))
+
 end


### PR DESCRIPTION
if an expression is used in condition of if_else and in one of the branches then code gen made that branch return nothing. Example:
```julia
julia>  h = make_function([if_else(sqrt(x) < 1, sqrt(x), 0.0)], [x])
RuntimeGeneratedFunction(#=in FastDifferentiation=#, #=using FastDifferentiation=#, :((input_variables,)->begin
          #= c:\Users\seatt\source\FastDifferentiation.jl\src\CodeGeneration.jl:229 =#
          #= c:\Users\seatt\source\FastDifferentiation.jl\src\CodeGeneration.jl:229 =# @inbounds begin
                  #= c:\Users\seatt\source\FastDifferentiation.jl\src\CodeGeneration.jl:230 =#
                  begin
                      result_element_type = promote_type(Float64, eltype(input_variables))
                      result = Array{result_element_type}(undef, (1,))
                      var"##319" = sqrt(input_variables[1])
                      var"##318" = var"##319" < 1
                      var"##317" = if var"##318"
                              #= c:\Users\seatt\source\FastDifferentiation.jl\src\CodeGeneration.jl:58 =#
                              begin #####ERROR here should return var"##319" in the true branch. But because this expression was used in the condition of if_else it was skipped as being already defined.
                              end
                          else
                              #= c:\Users\seatt\source\FastDifferentiation.jl\src\CodeGeneration.jl:60 =#
                              begin
                                  var"##s#320" = 0.0
                              end
                          end
                      result[1] = var"##317"
                      return result
                  end
              end
      end))
```