### PR TITLE
Fix multiarg code generation

### DIFF
--- a/src/CodeGeneration.jl
+++ b/src/CodeGeneration.jl
@@ -370,22 +370,22 @@ function make_function(func_array::AbstractArray{T}, input_variables::AbstractVe
 
 
     _single_arg_function = @RuntimeGeneratedFunction(make_Expr(func_array, all_input_vars, in_place, init_with_zeros))
-    expected_input_sizes = map(size, input_variables)
-    expected_result_size = size(func_array)
+    expected_input_lengths = map(length, input_variables)
+    expected_result_lengths = length(func_array)
     if in_place
-        compiled_function = function (result, input_variables::AbstractVector...)
-            @boundscheck if any(size(input) != expected_size for (input, expected_size) in zip(input_variables, expected_input_sizes))
-                throw(ArgumentError("The input variables must have the same size as the input_variables argument to make_function."))
+        compiled_function = function (result, input_variables...)
+            @boundscheck if any(length(input) != expected_length for (input, expected_length) in zip(input_variables, expected_input_lengths))
+                throw(ArgumentError("The input variables must have the same length as the input_variables argument to make_function. Expected lengths: $expected_input_lengths. Actual lengths: $(map(length, input_variables))."))
             end
-            @boundscheck if size(result) != expected_result_size
-                throw(ArgumentError("The result array must have the same size as the result of the function."))
+            @boundscheck if length(result) != expected_result_lengths
+                throw(ArgumentError("The result array must have the same length as the result of the function. Expected lengths: $expected_result_lengths. Actual lengths: $(length(result))."))
             end
             return _single_arg_function(result, reduce(vcat, input_variables))
         end
     else
-        compiled_function = function (input_variables::AbstractVector...)
-            @boundscheck if any(size(input) != expected_size for (input, expected_size) in zip(input_variables, expected_input_sizes))
-                throw(ArgumentError("The input variables must have the same size as the input_variables argument to make_function."))
+        compiled_function = function (input_variables...)
+            @boundscheck if any(length(input) != expected_length for (input, expected_length) in zip(input_variables, expected_input_lengths))
+                throw(ArgumentError("The input variables must have the same length as the input_variables argument to make_function. Expected lengths: $expected_input_lengths. Actual lengths: $(map(length, input_variables))."))
             end
             return _single_arg_function(reduce(vcat, input_variables))
         end

--- a/test/FDTests.jl
+++ b/test/FDTests.jl
@@ -2168,13 +2168,19 @@ end
 @testitem "multiarg code generation" begin
     using FastDifferentiation: FastDifferentiation as FD
 
+    # out-of-place case
     x = FD.make_variables(:x, 3)
     y = FD.make_variables(:y, 3)
     f = x .* y
     f_callable = FD.make_function(f, x, y)
-
     x_val = ones(3)
     y_val = ones(3)
     f_val = f_callable(x_val, y_val)
     @test f_val ≈ ones(3)
+
+    # in-place case
+    result = zeros(3)
+    f_callable! = FD.make_function(f, x, y; in_place=true)
+    f_callable!(result, x_val, y_val)
+    @test result ≈ ones(3)
 end

--- a/test/FDTests.jl
+++ b/test/FDTests.jl
@@ -1733,7 +1733,7 @@ end
     xprime = FD.Node.(x) #this will change the type of the vector
     fn = FD.make_function([xprime'mu], xprime, mu)
 
-    @test isapprox(fn([1, 2, 3, 4])[1], 11)
+    @test isapprox(fn([1, 2], [3, 4])[1], 11)
 end
 
 @testitem "reverse_AD" begin

--- a/test/FDTests.jl
+++ b/test/FDTests.jl
@@ -2164,3 +2164,17 @@ end
     @test isnan(h([0.0, 2.0])[1])
     @test isapprox(h([1.1, 2.0])[1], 0.11532531756323319)
 end
+
+@testitem "multiarg code generation" begin
+    using FastDifferentiation: FastDifferentiation as FD
+
+    x = FD.make_variables(:x, 3)
+    y = FD.make_variables(:y, 3)
+    f = x .* y
+    f_callable = FD.make_function(f, x, y)
+
+    x_val = ones(3)
+    y_val = ones(3)
+    f_val = f_callable(x_val, y_val)
+    @test f_val ≈ ones(3)
+end


### PR DESCRIPTION
# The Issue 

While the docstring for `make_function` suggests that one can pass multiple arrays of inputs, the code generation for such cases is currently broken. Without the changes of this PR, the following behavior occurs:

```julia
using FastDifferentiation: FastDifferentiation as FD

x = FD.make_variables(:x, 3)
y = FD.make_variables(:y, 3)
f = x .* y
f_callable = FD.make_function(f, x, y)

x_val = ones(3)
y_val = ones(3)
f_val = f_callable(x_val, y_val)
@test f_val ≈ ones(3) # fails due to access to uninitialized memory
```

Without this PR, this MVP generates the following code:

```julia
RuntimeGeneratedFunction(#=in FastDifferentiation=#, #=using FastDifferentiation=#, :((input_variables,)->begin
          #= /home/lassepe/worktree/FastDifferentiation.jl/src/CodeGeneration.jl:229 =#
          #= /home/lassepe/worktree/FastDifferentiation.jl/src/CodeGeneration.jl:229 =# @inbounds begin
                  #= /home/lassepe/worktree/FastDifferentiation.jl/src/CodeGeneration.jl:230 =#
                  begin
                      result_element_type = promote_type(Float64, eltype(input_variables))
                      result = Array{result_element_type}(undef, (3,))
                      var"##2814" = input_variables[1] * input_variables[4]
                      result[1] = var"##2814"
                      var"##2815" = input_variables[2] * input_variables[5]
                      result[2] = var"##2815"
                      var"##2816" = input_variables[3] * input_variables[6]
                      result[3] = var"##2816"
                      return result
                  end
              end
      end))
```

Observe that the generate code assumes a single argument that is accessed at indices 4, 5, and 6. This memory access is out of bounds which remains unnoticed due to the `@inbounds` annotation.

# This PR

This PR fixes this issue by wrapping the `RuntimeGeneratedFunction` in function that
- checks the sizes of all inputs
- concatenates input arrays before passing them one to the generated function

# Recommendations

I see the proposed change primarily as a hotfix.
I believe that the proper fix for this would be to change `make_Expr`. However, since `input_variables` is not the last positional argument to that function, it cannot be a `VarArg`. Hence, it seems difficult to fix that function without a breaking change. If a breaking change were acceptable, I would recommend to:

- change the signature of `make_Expr` to `make_Expr(func_array::AbstractArray{T}, input_variables::AbstractVector{S}...; in_place::Bool, init_with_zeros::Bool)
- directly generate a multi-arg function (which is supported by `RuntimeGeneratedFunction` and would save a costly `reduce(vcat, inputs)` at runtime)
- add a bounds-check to each input. Otherwise, if the user passes an input that is too short they may get undefined behavior. Users can always eliminate such bounds-check by explictly wrapping the callsite in `@inbounds`