### PR TITLE
Fix multi-arg code generation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastDifferentiation"
 uuid = "eb9bf01b-bf85-4b60-bf87-ee5de06c00be"
 authors = ["BrianGuenter"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/docs/src/makefunction.md
+++ b/docs/src/makefunction.md
@@ -39,6 +39,17 @@ julia> f_exe!([2.0,3.0])
  9.0
 ```
 
+Example: generated function accepts more than one vector of input arguments. This is useful if you want to segregate your input variables into groups.
+```julia
+    x = make_variables(:x, 3)
+    y = make_variables(:y, 3)
+    f = x .* y
+    f_callable = make_function(f, x, y)
+    x_val = ones(3)
+    y_val = ones(3)
+    f_val = f_callable(x_val, y_val) #executable takes two 3-vectors as input arguments
+```
+
 Example: assume your result is a large dense array (> 100 elements) and that you are using an in place array with no initialization. For dense arrays this should generate the fastest code:
 ```
 julia> @variables x y z

--- a/src/ExpressionGraph.jl
+++ b/src/ExpressionGraph.jl
@@ -484,11 +484,11 @@ function to_string(a::Node)
     end
 end
 
-function node_symbol(a::Node, variable_to_index::IdDict{Node,Int64})
+function node_symbol(a::Node, variable_to_index::IdDict{Node,Union{Expr,Int64}})
     if is_tree(a)
         result = gensym() #create a symbol to represent the node
     elseif is_variable(a)
-        result = :(input_variables[$(variable_to_index[a])])
+        result = :($(variable_to_index[a]))
     else
         result = value(a) #not a tree not a variable so is some kind of constant.
     end

--- a/test/FDTests.jl
+++ b/test/FDTests.jl
@@ -1776,29 +1776,29 @@ end
     p = make_variables(:p, 21)
 
     println("NO array zero statement")
-    show(make_Expr(p, p, true, true))
-    show(make_Expr(p, p, true, false))
-    show(make_Expr(p, p, false, true))
-    show(make_Expr(p, p, false, false))
+    show(make_Expr(p, p, in_place=true, init_with_zeros=true))
+    show(make_Expr(p, p, in_place=true, init_with_zeros=false))
+    show(make_Expr(p, p, in_place=false, init_with_zeros=true))
+    show(make_Expr(p, p, in_place=false, init_with_zeros=false))
 
     p[21] = 0
 
     println("shouldn't have an array zero statement but it should have a p[21]= 0 statement")
-    show(make_Expr(p, p, true, true))
+    show(make_Expr(p, p, in_place=true, init_with_zeros=true))
     println("this should not have an array zero statement nor should have a p[21] = 0 statement")
-    show(make_Expr(p, p, true, false))
+    show(make_Expr(p, p, in_place=true, init_with_zeros=false))
     println("should not have an array zero statement but should have a p[21] = 0 statement")
-    show(make_Expr(p, p, false, true))
-    show(make_Expr(p, p, false, false))
+    show(make_Expr(p, p, in_place=false, init_with_zeros=true))
+    show(make_Expr(p, p, in_place=false, init_with_zeros=false))
 
     p[20] = 0
     println("this should have an array zero statement should not have p[20]=0 or p[21]=0 statementt")
-    show(make_Expr(p, p, true, true))
+    show(make_Expr(p, p, in_place=true, init_with_zeros=true))
     println("this should not have an array zero statement should not have p[20]=0 or p[21]=0 statement")
-    show(make_Expr(p, p, true, false))
+    show(make_Expr(p, p, in_place=true, init_with_zeros=false))
     println("these should both have an array zero creation but should not have p[20]=0 or p[21]=0 statement")
-    show(make_Expr(p, p, false, true))
-    show(make_Expr(p, p, false, false))
+    show(make_Expr(p, p, in_place=false, init_with_zeros=true))
+    show(make_Expr(p, p, in_place=false, init_with_zeros=false))
 end
 
 

--- a/test/FDTests.jl
+++ b/test/FDTests.jl
@@ -1733,7 +1733,7 @@ end
     xprime = FD.Node.(x) #this will change the type of the vector
     fn = FD.make_function([xprime'mu], xprime, mu)
 
-    @test isapprox(fn([1, 2, 3, 4])[1], 11)
+    @test isapprox(fn([1, 2], [3, 4])[1], 11)
 end
 
 @testitem "reverse_AD" begin


### PR DESCRIPTION
This is based on https://github.com/brianguenter/FastDifferentiation.jl/pull/103. That PR proposed a temporary hotfix. Instead I decided to do the more complex long term fix.

While the docstring for make_function suggests that one can pass multiple arrays of inputs, the code generation for such cases is currently broken. Without the changes of this PR, the following behavior occurs:

using FastDifferentiation: FastDifferentiation as FD

x = FD.make_variables(:x, 3)
y = FD.make_variables(:y, 3)
f = x .* y
f_callable = FD.make_function(f, x, y)

x_val = ones(3)
y_val = ones(3)
f_val = f_callable(x_val, y_val)
@test f_val ≈ ones(3) # fails due to access to uninitialized memory
Without this PR, this MVP generates the following code:

RuntimeGeneratedFunction(#=in FastDifferentiation=#, #=using FastDifferentiation=#, :((input_variables,)->begin
          #= /home/lassepe/worktree/FastDifferentiation.jl/src/CodeGeneration.jl:229 =#
          #= /home/lassepe/worktree/FastDifferentiation.jl/src/CodeGeneration.jl:229 =# @inbounds begin
                  #= /home/lassepe/worktree/FastDifferentiation.jl/src/CodeGeneration.jl:230 =#
                  begin
                      result_element_type = promote_type(Float64, eltype(input_variables))
                      result = Array{result_element_type}(undef, (3,))
                      var"##2814" = input_variables[1] * input_variables[4]
                      result[1] = var"##2814"
                      var"##2815" = input_variables[2] * input_variables[5]
                      result[2] = var"##2815"
                      var"##2816" = input_variables[3] * input_variables[6]
                      result[3] = var"##2816"
                      return result
                  end
              end
      end))
Observe that the generate code assumes a single argument that is accessed at indices 4, 5, and 6. This memory access is out of bounds which remains unnoticed due to the @inbounds annotation.

This PR corrects this so multi-arg code generation works. Also adds runtime checks to ensure input arguments are the expected length. For the in-place case also verifies that the result matrix has the correct size.